### PR TITLE
fix: ensure checker exist on dispose

### DIFF
--- a/src/parser/meta-parser.ts
+++ b/src/parser/meta-parser.ts
@@ -233,7 +233,9 @@ export function useComponentMetaParser (
     get checker () { return checker },
     get components () { return components },
     dispose() {
-      checker.clearCache()
+      if (checker) {
+        checker.clearCache()
+      }
       // @ts-expect-error - Remove checker
       checker = null
       // Clear components cache


### PR DESCRIPTION
This ensures `clearCache` method is not called when `dispose` has already been called